### PR TITLE
remove blank lines near the doctype and html tags

### DIFF
--- a/Resources/views/base.html.twig
+++ b/Resources/views/base.html.twig
@@ -1,12 +1,11 @@
-{% from 'MopaBootstrapBundle::flash.html.twig' import session_flash %}
+{% from 'MopaBootstrapBundle::flash.html.twig' import session_flash -%}
 
 <!DOCTYPE html>
-
 {% block html_tag %}
 <html>
 {% endblock html_tag %}
 
-{% block head %}
+{%- block head %}
 <head>
     <meta charset="UTF-8" />
     {% block head_style %}


### PR DESCRIPTION
Change the html layout output from:
"

<!DOCTYPE html>

<html lang="en">..."

TO:

"<!DOCTYPE html>
<html lang="en">"